### PR TITLE
Updated stale.yml file to stale/close issues.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,20 @@
-name: Mark and close stale pull requests
+# This workflow alerts and then closes the stale issues/PRs after specific time
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+
+
+name: Mark and close stale PRs/issues
 
 on:
   schedule:
   - cron: "30 1 * * *"
+  
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   stale:
@@ -10,9 +22,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v3.0.8
+    - uses: actions/stale@v7
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
         days-before-stale: 30
         days-before-close: 5
+        
+        # comment on issues if not active for more then 14 days.
+        stale-issue-message: 'This issue has been automatically marked as stale because it has no recent activity. It will be closed if no further activity occurs. Thank you.'
+        
+        #comment on issues if stale for more then 14 days. 
+        close-issue-message: "Closing as stale. Please reopen if you'd like to work on this further"
+              
+        # Number of days of inactivity before a stale issue is closed
+        days-before-issue-close: 14
+        
+        # Number of days of inactivity before an issue Request becomes stale
+        days-before-issue-stale: 14
+         
+        #Check for label to stale or close the issue/PR
+        any-of-labels: 'stat:awaiting response'
+         
+        #override stale to stalled for issue
+        stale-issue-label: 'Stalled'


### PR DESCRIPTION
I've updated the workflow file to replace 'stale-master' probot. It will add 'stalled' label to inactive issues if contains 'stat:awaiting response' label in case of further inactivity it will close the issue with proper comment.